### PR TITLE
Add Evil mode rules

### DIFF
--- a/eink-theme.el
+++ b/eink-theme.el
@@ -89,6 +89,11 @@
    `(mode-line-inactive ((t (:background ,bg-light :foreground ,bg-light :height 0.8))))
    `(mode-line-minor-mode ((t (:weight ultra-light))))
    `(modeline ((t (:background ,bg :foreground ,fg :height 0.8))))
+   `(region ((t (:background "#eeeee8" :foreground ,fg))))
+   `(slime-repl-inputed-output-face ((t (:foreground ,fg))))
+   `(whitespace-line ((t (:background ,bg-highlight-2 :foreground ,fg))))
+
+   ;; org
    `(org-agenda-date ((t (:foreground ,fg :height 1.2))))
    `(org-agenda-date-today ((t (:foreground ,fg :weight bold :height 1.4))))
    `(org-agenda-date-weekend ((t (:foreground ,fg :weight normal))))
@@ -113,9 +118,6 @@
    `(org-special-keyword ((t (:foreground ,fg))))
    `(org-todo ((t (:foreground ,fg))))
    `(org-verse ((t (:inherit org-block :slant italic))))
-   `(region ((t (:background "#eeeee8" :foreground ,fg))))
-   `(slime-repl-inputed-output-face ((t (:foreground ,fg))))
-   `(whitespace-line ((t (:background ,bg-highlight-2 :foreground ,fg))))
 
    ;; magit
    `(magit-header ((t (:weight bold))))

--- a/eink-theme.el
+++ b/eink-theme.el
@@ -192,7 +192,12 @@
    `(idle-highlight ((t (:background ,bg-highlight))))
    `(yas-field-highlight-face ((t (:background "#eeeee8" :foreground ,fg))))
    `(eshell-prompt ((t (:foreground ,fg :weight bold))))
-   `(cider-result-overlay-face ((t (:weight bold))))))
+   `(cider-result-overlay-face ((t (:weight bold))))
+
+   ;; evil
+   `(evil-ex-lazy-highlight ((t (:background ,bg-highlight-2))))
+   `(evil-ex-substitute-matches ((t (:background ,bg-highlight-2))))
+   `(evil-ex-substitute-replacement ((t (:background ,bg-highlight :underline nil :foreground ,fg))))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
The isearch face is still the same, but Evil introduces a `evil-ex-lazy-highlight` face which just highlights whatever matched the search after the search has been done. Example in pic:

![2016-05-16-220844_679x369_scrot](https://cloud.githubusercontent.com/assets/2314074/15310154/0a1572f8-1bb3-11e6-80b6-b5d5e4911f22.png)

It also adds a search and replace function (`:%s/search/replace/`), the `search` gets its own face and so does the `replace`, so I added those as well, example in pic:

![2016-05-16-221008_679x369_scrot](https://cloud.githubusercontent.com/assets/2314074/15310155/0a172d5a-1bb3-11e6-907b-489d724e3d94.png)

In addition it adds a header for the Org-mode styles, which previously were under the "generic" heading.
