### PR TITLE
Add rules for evil-quickscope

### DIFF
--- a/eink-theme.el
+++ b/eink-theme.el
@@ -194,6 +194,10 @@
    `(eshell-prompt ((t (:foreground ,fg :weight bold))))
    `(cider-result-overlay-face ((t (:weight bold))))
 
+   ;; evil-quickscope
+   `(evil-quickscope-first-face ((t (:foreground ,fg :background "#eeeee8"))))
+   `(evil-quickscope-second-face ((t (:foreground ,fg :background ,bg-highlight))))
+
    ;; evil
    `(evil-ex-lazy-highlight ((t (:background ,bg-highlight-2))))
    `(evil-ex-substitute-matches ((t (:background ,bg-highlight-2))))


### PR DESCRIPTION
Adds support for evil-quickscope https://github.com/blorbx/evil-quickscope, nice GIF of functionality in the original plugin for Vim https://github.com/unblevable/quick-scope.

![2016-05-21-192533_679x369_scrot](https://cloud.githubusercontent.com/assets/2314074/15451482/d13336ac-1f89-11e6-8bab-e274c8c4563d.png)

Tried to make it subtle but still easy to recognize.
